### PR TITLE
Suppress installation warning with React 17

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "prepare": "tsdx build"
   },
   "peerDependencies": {
-    "react": ">=16"
+    "react": "^16.14.0 || ^17.0.0"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
Adding this (very handy, thank you!) package to a React 17 site, I got this warning:

```
warning " > powered-by-vercel@1.0.1" has unmet peer dependency "react@>=16".
```

Making it handle either v16 or 17 without the warning with this PR!